### PR TITLE
Update function names used in the legacy ajax class

### DIFF
--- a/framework/ajax/legacy.php
+++ b/framework/ajax/legacy.php
@@ -11,10 +11,10 @@ function legacy() {
     $ajax = new class {
       function enqueue() { return ajax\enqueue(); }
       function register_library() {
-        return ajax\register_library();
+        return ajax\register();
       }
       function conditional_enqueue_library() {
-        return ajax\conditional_enqueue_library();
+        return ajax\conditional_enqueue();
       }
       function add_action($name, $fn, $options = []) {
         return ajax\add_action($name, $fn, $options);

--- a/integrations/elementor/index.php
+++ b/integrations/elementor/index.php
@@ -46,8 +46,8 @@ add_action( 'elementor/editor/init', function() use ( $plugin ) {
 add_action( 'elementor/editor/before_enqueue_scripts', $html->head_action, 99 );
 add_action( 'elementor/editor/footer', $html->footer_action, 99 );
 
-add_action('elementor/editor/before_enqueue_scripts', 'tangible\\ajax\\register_library', 1);
-add_action('elementor/editor/before_enqueue_scripts', 'tangible\\ajax\\conditional_enqueue_library', 9999);
+add_action('elementor/editor/before_enqueue_scripts', 'tangible\\ajax\\register', 1);
+add_action('elementor/editor/before_enqueue_scripts', 'tangible\\ajax\\conditional_enqueue', 9999);
 
 
 /**


### PR DESCRIPTION
It seems that there is a small issue in the function names used inside the [legacy ajax class](framework/ajax/legacy.php)

I believe `ajax\register_library()` and `ajax\conditional_enqueue_library()` should be `ajax\register()` and `ajax\conditional_enqueue()`  