### PR TITLE
Framework: Interface module - Update namespace for compatibility with older PHP versions

### DIFF
--- a/framework/interface/index.php
+++ b/framework/interface/index.php
@@ -3,7 +3,7 @@
  * Interface module removed - This is for compatibility with existing
  * plugins until they remove reference to it.
  */
-namespace tangible\interface;
+namespace tangible\interfaces;
 
 function legacy() {
   static $interface;

--- a/language/index.php
+++ b/language/index.php
@@ -65,7 +65,7 @@ return tangible_template(new class extends stdClass {
     // @see /framework
     $system->date = $html->date = tangible\date();
     $system->ajax = tangible\ajax\legacy();
-    $system->interface = tangible\interface\legacy();
+    $system->interface = tangible\interfaces\legacy();
 
     /**
      * Template language


### PR DESCRIPTION
Using interface in a namespace before PHP 8 will throw an error (see [this snippet](https://onlinephp.io?s=s7EvyCjg5eLlykvMTS0uSExOVShJzEvPTMpJjcnMK0ktSgMKWYMUAAA%2C&v=8.1.27%2C8.0.30%2C7.4.33%2C8.2.5))

This pull request update the namespace used inside the interface module from `tangible\interface` to `tangible\interfaces`