### PR TITLE
Framework: Date module - Update static declaration to be compatible with PHP 8.0 and lower

### DIFF
--- a/framework/date/index.php
+++ b/framework/date/index.php
@@ -9,7 +9,8 @@
 namespace tangible;
 
 function date( $arg = false ) {
-  static $date = new DateCreator;
+  static $date;
+  if (!$date) $date = new DateCreator;
   return $arg !== false
     ? call_user_func_array($date, func_get_args())
     : $date


### PR DESCRIPTION
It seems that we can't instantiate a class during a static variable definition in PHP 8.0 and lower (see [example snippet](https://onlinephp.io?s=s7EvyCjg5eLlSs5JLC5WCEktLlGorgUJpJXmJZdk5ucp5CXmpmpoKlTzcnEWlySWZCYrqJQlFmUmJuWkKtgq5KWWg3VZ83LVAgA%2C&v=8.1.27%2C8.0.30%2C7.4.33%2C8.2.5))