### PR TITLE
WP Fusion: Remove use tangible\create_object and add namespace when calling the function instead

### DIFF
--- a/integrations/wp-fusion/index.php
+++ b/integrations/wp-fusion/index.php
@@ -4,9 +4,6 @@
  *
  * @see tangible-blocks-pro/includes/integrations/index.php
  */
-
-use tangible\create_object;
-
 add_action('tangible_template_system_ready', function( $template_system ) use ( $plugin, $loop, $logic, $html ) {
 
   $key = 'wp-fusion';
@@ -23,7 +20,7 @@ add_action('tangible_template_system_ready', function( $template_system ) use ( 
   // Each integration gets its own instance of $plugin
 
   $name = str_replace( '-', '_', $key );
-  $plugin = create_object([
+  $plugin = tangible\create_object([
     'name' => 'template_system_' . $name . '_integration',
     'config' => $config,
   ]);


### PR DESCRIPTION
I noticed that someone reported this issue on discourse earlier today: https://discourse.tangible.one/t/4-0-0-fatal-error-with-wp-fusion/1175