### PR TITLE
Framework: Ajax module - Remove exit after wp_send_json_success/error

### DIFF
--- a/framework/ajax/actions.php
+++ b/framework/ajax/actions.php
@@ -10,12 +10,10 @@ function error($data = []) {
       ? $data->getMessage()
       : (is_string($data) ? [ 'message' => $data ] : $data)
   );
-  exit;
 };
 
 function success($data = []) {
   wp_send_json_success($data);
-  exit;
 };
 
 function add_action($name, $fn, $options = []) {


### PR DESCRIPTION
Hi!

This pull request remove the `exit` after `wp_send_json_success()` and `wp_send_json_error()` in the ajax module

I would like to remove it so that it can be bypassed more easily in tests. Here is the function I'm using to test ajax actions currently (from [here](https://bitbucket.org/tangibleinc/tangible-live/src/e83b01d1fee17198e9d9c741dd56b85a89a0367b/tests/phpunit/utils.php#lines-34:53)):
```php
function test_ajax_action( string $name, array $args = [] ) : array {

  $_POST['nonce'] = \tangible\ajax\create_nonce(); 
  $_POST['data'] = $args;

  add_filter( 'wp_doing_ajax', '__return_true', 10 );
  add_filter( 'wp_die_ajax_handler', $filter = function() { return function() {}; }, 10 );
  
  ob_start();
  do_action( 'wp_ajax_tangible_ajax_' . $name );
  $response = ob_get_clean();

  remove_filter( 'wp_doing_ajax', '__return_true', 10 );
  remove_filter( 'wp_die_ajax_handler', $filter, 10 );

  unset( $_POST['nonce'] ); 
  unset( $_POST['data'] ); 

  return json_decode( $response, true );
}
```

I initially wanted to replace it with `wp_die()`, but it seems to be already called [at the end of `wp_send_json()` when doing ajax](https://github.com/WordPress/wordpress-develop/blob/6.5/src/wp-includes/functions.php#L4471-L4505)

If it's not possible to remove the exits or if that would make more sense, I can also update the pull request and use `exit` only when `DOING_TANGIBLE_TEST` is not defined, or add our own filter so that it can still be bypassed