### PR TITLE
Framework: API module - Prevent recursive call

### DIFF
--- a/framework/api/rest/routes.php
+++ b/framework/api/rest/routes.php
@@ -225,7 +225,17 @@ new class {
     if ( $validate_uri > 0 ) {
       return $user;
     }
+
+    /**
+     * We are using localized strings as error messages in validate_token()
+     *
+     * When looking for the current locale, it might call _wp_get_current_user()
+     * which will apply the determine_current_user filter again (and will create an
+     * infinite loop)
+     */
+    remove_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 99 );
     $token = $this->validate_token( false );
+    add_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 99 );
 
     if ( is_wp_error( $token ) ) {
       if ( $token->get_error_code() !== 'jwt_auth_no_auth_header' ) {


### PR DESCRIPTION
Hi Eliot!

I recently noticed an issues with some endpoints that returns a 503 error on sites where the framework is used

The issue can be reproduced by creating or updating a new page on a WordPress site 

The requests made on the initial page load will return a 503 error:

![Screenshot from 2024-05-07 12-02-02](https://github.com/TangibleInc/template-system/assets/33153717/04f576f5-201e-42b1-95a0-325ab2cf80cc)

All those requests pass `_locale` as a GET parameter, and the issue seems to only happen when this parameter is set

In the error logs, there is the following error for each request:
```
PHP Fatal error:  Uncaught Error: Xdebug has detected a possible infinite loop, and aborted your script with a stack depth of '512' frames in /var/www/html/tangiblelive/wp-includes/class-wp-object-cache.php:14
```

From the associated stack trace it seems that there is indeed an infinite loop, caused by the `determine_current_user` filter we set in `routes.php` ([here](https://github.com/TangibleInc/template-system/blob/main/framework/api/rest/routes.php#L32)), which will trigger the `determine_current_user` filter again (by calling `validate_token`, [here](https://github.com/TangibleInc/template-system/blob/main/framework/api/rest/routes.php#L228)):
```
# [...]
#429 /var/www/html/tangiblelive/wp-content/plugins/tangible-live/vendor/tangible/framework/api/rest/routes.php(268): __()
#430 /var/www/html/tangiblelive/wp-content/plugins/tangible-live/vendor/tangible/framework/api/rest/routes.php(228): class@anonymous->validate_token()
#431 /var/www/html/tangiblelive/wp-includes/class-wp-hook.php(324): class@anonymous->determine_current_user()
#432 /var/www/html/tangiblelive/wp-includes/plugin.php(205): WP_Hook->apply_filters()
#433 /var/www/html/tangiblelive/wp-includes/user.php(3632): apply_filters()
#434 /var/www/html/tangiblelive/wp-includes/pluggable.php(70): _wp_get_current_user()
#435 /var/www/html/tangiblelive/wp-includes/l10n.php(98): wp_get_current_user()
#436 /var/www/html/tangiblelive/wp-includes/l10n.php(152): get_user_locale()
#437 /var/www/html/tangiblelive/wp-includes/l10n.php(1353): determine_locale()
#438 /var/www/html/tangiblelive/wp-includes/l10n.php(1384): _load_textdomain_just_in_time()
#439 /var/www/html/tangiblelive/wp-includes/l10n.php(194): get_translations_for_domain()
#440 /var/www/html/tangiblelive/wp-includes/l10n.php(306): translate()
#441 /var/www/html/tangiblelive/wp-content/plugins/tangible-live/vendor/tangible/framework/api/rest/routes.php(268): __()
#442 /var/www/html/tangiblelive/wp-content/plugins/tangible-live/vendor/tangible/framework/api/rest/routes.php(228): class@anonymous->validate_token()
#443 /var/www/html/tangiblelive/wp-includes/class-wp-hook.php(324): class@anonymous->determine_current_user()
#444 /var/www/html/tangiblelive/wp-includes/plugin.php(205): WP_Hook->apply_filters()
# [...]
```

The issue seems to come from the `WP_Error` returned [here](https://github.com/TangibleInc/template-system/blob/main/framework/api/rest/routes.php#L266-L272) inside `validate_token`

Because [the error message is localized](https://github.com/TangibleInc/template-system/blob/main/framework/api/rest/routes.php#L268), WordPress will try to look for the current user local and will end-up calling `_wp_get_current_user`, which will trigger the `determine_current_user` filter and call our method again

The reason it only affect requests that pass `_locale` as a GET parameter seems to be because of [this condition in determine_locale()](https://github.com/WordPress/wordpress-develop/blob/6.5/src/wp-includes/l10n.php#L148-L152)

This pull request should prevent this loop by removing our filter before calling `validate_token`
