### PR TITLE
Add support for instant templating with shortcode

### DIFF
--- a/admin/template-post/tag.php
+++ b/admin/template-post/tag.php
@@ -62,6 +62,11 @@ $plugin->template_tag_and_shortcode = function($atts, $nodes = []) use ($plugin,
     unset($atts['title']);
   }
 
+  if (empty($post) && $nodes) {
+    // Create a temporary post object
+    $post = new WP_Post((object) ['ID' => 1, 'post_content' => $nodes]);
+  } 
+
   if (empty($post)) return;
 
   unset($atts['keys']);


### PR DESCRIPTION
this small change allows to render a template instantly without creating any post type.

example:

```html
[template]
<Loop type=post orderby=date order=desc count=6>
<div class="card">
	<Field title />
</div>
</Loop>
[/template]
```

This will work even in the classic editor