### PR TITLE
Framework: Plugin features - Update documentation example

### DIFF
--- a/framework/plugin/readme.md
+++ b/framework/plugin/readme.md
@@ -19,9 +19,9 @@ add_action('plugins_loaded', function() {
     'dir_path' => plugin_dir_path( __FILE__ ),
     'url' => plugins_url( '/', __FILE__ ),
     'assets_url'     => plugins_url( '/assets', __FILE__ ),
+    // ...Load plugin features
   ]);
 
-  // ...Load plugin features
 });
 ```
 
@@ -72,8 +72,8 @@ Each feature has these properties:
 - `default` - Optional: Set `true` to enable the feature by default
 
 ```php
-framework\register_plugin_settings($plugin, [
-  // ...Other settings
+$plugin = framework\register_plugin([
+  // ...Plugin configuration
   'features' => [
     [
       'name' => 'example',
@@ -87,6 +87,10 @@ framework\register_plugin_settings($plugin, [
       'default' => true,
     ],
   ],
+]);
+
+framework\register_plugin_settings($plugin, [
+  // ...Other settings
   'tabs' => [
     // ...Other tabs
     'features' => [


### PR DESCRIPTION
Hi @eliot-akira!

It seems that there is a small issue with the example for registering plugin features

The example currently register the features during the `framework\register_plugin_settings` function:
```php
framework\register_plugin_settings($plugin, [
  // ...Other settings
  'features' => [
    [
      'name' => 'example',
      'title' => 'First feature',
      'entry_file' => __DIR__ . '/example.php'
    ],
    [
      'name' => 'example_2',
      'title' => 'Second feature',
      'entry_file' => __DIR__ . '/example-2.php'
      'default' => true,
    ],
  ]
]);
```

It looks like features are initialized by the `framework\load_plugin_features` function, which is itself called inside the `register_plugin` function ([here](https://github.com/TangibleInc/framework/blob/main/plugin/index.php#L24))

So if we set up the features inside the `framework\register_plugin_settings`, it looks like it's going to be too late for the entry file of the feature to be loaded

This pull request update the example to this instead:

```php
$plugin = framework\register_plugin([
  // ...Plugin configuration
  'features' => [
    [
      'name' => 'example',
      'title' => 'First feature',
      'entry_file' => __DIR__ . '/example.php'
    ],
    [
      'name' => 'example_2',
      'title' => 'Second feature',
      'entry_file' => __DIR__ . '/example-2.php'
      'default' => true,
    ],
  ],
]);

framework\register_plugin_settings($plugin, [
  // ...Other settings
  'tabs' => [
    // ...Other tabs
    'features' => [
      'title' => 'Features',
      'callback' => function() use ($plugin) {
        framework\render_features_settings_page($plugin);
      }
    ],
  ],
]);
```