### PR TITLE
Framework: Plugin features - Switch compatibility with chromium

### DIFF
--- a/framework/plugin/settings/checkbox.php
+++ b/framework/plugin/settings/checkbox.php
@@ -38,7 +38,7 @@ function render_setting_field_checkbox($config) {
     <?php elseif ($type === 'switch'): ?>
         <div class="tangible-card">
             <label class="tangible-feature-switch" role="switch" aria-checked="<?php echo $checked ? 'true' : 'false'; ?>" tabindex="0" 
-            onclick="this.querySelector('input[type=checkbox]').checked = ! this.querySelector('input[type=checkbox]').checked;"
+            onclick="this.querySelector('input[type=checkbox]').checked ^= 1"
             onkeydown="if (event.key === ' ' || event.key === 'Enter') { 
                 const checkbox = this.querySelector('input[type=checkbox]') 
                 checkbox.checked = !checkbox.checked

--- a/framework/plugin/settings/checkbox.php
+++ b/framework/plugin/settings/checkbox.php
@@ -38,7 +38,7 @@ function render_setting_field_checkbox($config) {
     <?php elseif ($type === 'switch'): ?>
         <div class="tangible-card">
             <label class="tangible-feature-switch" role="switch" aria-checked="<?php echo $checked ? 'true' : 'false'; ?>" tabindex="0" 
-            onclick="this.querySelector('input[type=checkbox]').click();" 
+            onclick="this.querySelector('input[type=checkbox]').checked = ! this.querySelector('input[type=checkbox]').checked;"
             onkeydown="if (event.key === ' ' || event.key === 'Enter') { 
                 const checkbox = this.querySelector('input[type=checkbox]') 
                 checkbox.checked = !checkbox.checked


### PR DESCRIPTION
Hi @eliot-akira!

It looks like currently we are not able to change the value of a switch control on chromium based browsers

It seems that unlike in firefox, this snippet won't trigger a value change on a checkbox input:
```javascript
this.querySelector('input[type=checkbox]').click();"
```

This pull request just change it to this, so that it's compatible with chromium based browsers as well:
```javascript
this.querySelector('input[type=checkbox]').checked = ! this.querySelector('input[type=checkbox]').checked
```
