### PR TITLE
Start optional object cache for parsed and preprocessed template posts

### DIFF
--- a/admin/settings/index.php
+++ b/admin/settings/index.php
@@ -49,6 +49,14 @@ template_system::$state->setting_fields = [
   ],
 
   [
+    'name' => 'object_cache_processed_template_post',
+    'field_type' => 'checkbox',
+    'label' => 'Object cache for parsed and pre-processed template posts (Experimental)',
+    'default_value' => false,
+    'beta' => true,
+  ],
+
+  [
     'name' => 'sass_in_browser',
     'field_type' => 'checkbox',
     'label' => 'Use offical Sass compiler (dart-sass) in the browser. This compiles template style field into CSS when the post is saved. Previously they were rendered on template load using SCSS-PHP on the server.',
@@ -106,11 +114,21 @@ function get_settings( $field_name = null, $default_value = null ) {
   return $settings;
 }
 
+// Alias
+function get_setting( $field_name = null, $default_value = null ) {
+  return get_settings($field_name, $default_value);
+}
+
 function set_settings( $settings ) {
-
   update_option( template_system::$state->settings_key, $settings );
-
   return $settings;
+}
+
+function set_setting( $key, $value ) {
+  $settings = template_system\get_settings();
+  if (!is_array($settings)) $settings = [];
+  $settings[ $key ] = $value;
+  return template_system\set_settings( $settings );
 }
 
 function settings_page() {

--- a/admin/settings/page.php
+++ b/admin/settings/page.php
@@ -1,5 +1,6 @@
 <?php
 namespace tangible\template_system;
+
 use tangible\api;
 use tangible\template_system;
 

--- a/admin/template-post/cache.php
+++ b/admin/template-post/cache.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Object cache for pre-processed template posts
+ * 
+ * > Use the Transients API if you need to guarantee that your data will be cached. If persistent caching is configured, then the transients functions will use the wp_cache_* functions described in this document. However if persistent caching has not been enabled, then the data will instead be cached to the options table.
+ * 
+ * @see https://developer.wordpress.org/apis/transients
+ * @see https://developer.wordpress.org/reference/classes/wp_object_cache/
+ * @see https://developer.wordpress.org/advanced-administration/performance/cache/
+ */
+namespace tangible\template_system;
+
+use tangible\html;
+use tangible\template_system;
+
+function is_processed_template_post_cache_enabled() {
+  // See /admin/settings
+  return template_system\get_setting('object_cache_processed_template_post');
+}
+
+function get_template_post_cache_key($post) {
+  $type = $post->post_type;
+  $id = $post->ID;
+  return 'tangible_template_post_' . $type . '_' . $id;
+}
+
+function get_processed_template_post_with_cache( $post ) {
+
+  $cache_key = template_system\get_template_post_cache_key($post);
+
+  // \tangible\see( $post);
+
+  if (($processed = get_transient($cache_key))!==false) {
+    return $processed;
+  }
+
+  return template_system\process_and_cache_template_post($post, $cache_key);
+}
+
+/**
+ * Process and cache post content
+ */
+function process_and_cache_template_post( $post, $cache_key = null ) {
+
+  if (empty($cache_key)) {
+    $cache_key = template_system\get_template_post_cache_key($post);  
+  }
+
+  $metadata = [
+    'time' => gmdate('Y-m-d H:i:s'),
+    'type' => $post->post_type,
+    'id' => $post->ID
+  ];
+  $prefix = '<!-- Parsed and cached: ' . json_encode($metadata) . " -->\n";
+  $content = html\parse( $prefix . ($post->post_content) );
+  $processed = [
+    'parsed_content' => $content,
+    // ..Possibly other pre-processed template data
+  ] + $metadata;
+
+  set_transient($cache_key, $processed);
+
+  return $processed;
+}
+
+/**
+ * Flush cache
+ */
+function delete_processed_template_post_cache( $post ) {
+  return delete_transient(
+    template_system\get_template_post_cache_key($post)
+  );
+}

--- a/admin/template-post/index.php
+++ b/admin/template-post/index.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/cache.php';
 require_once __DIR__ . '/data.php';
 require_once __DIR__ . '/fields.php';
 require_once __DIR__ . '/save.php';

--- a/admin/template-post/save.php
+++ b/admin/template-post/save.php
@@ -1,4 +1,5 @@
 <?php
+use tangible\template_system;
 
 $plugin->is_saving_template_post = false;
 
@@ -97,6 +98,13 @@ $plugin->save_template_post = function( $data = [] ) use ( $plugin, $html ) {
     if ( isset( $fields['style'] ) ) {
       $plugin->maybe_save_style_compiled( $post, $fields['style'] );
     }
+
+    /**
+     * Optionally pre-process template post on save
+     */
+    if (template_system\is_processed_template_post_cache_enabled()) {
+      template_system\process_and_cache_template_post( $post );
+    }
   }
 
   return $result;
@@ -144,6 +152,13 @@ add_action( 'wp_after_insert_post', function( $post_id, $post, $update ) use ( $
     if ( $key === 'style' ) {
       $plugin->maybe_save_style_compiled( $post, $value );
     }
+  }
+
+  /**
+   * Optionally pre-process template post on save
+   */
+  if (template_system\is_processed_template_post_cache_enabled()) {
+    template_system\process_and_cache_template_post( $post );
   }
 
 }, 10, 3 );


### PR DESCRIPTION
- Resolves #127

This pull request implements a minimal basis for an optional object cache for parsed template posts. And in the future possibly other pre-processed and cached data.

It's similar in direction to the previous prototype except:

- Implemented as an admin feature of the template system, instead of in the HTML parser
- Only caches template posts, instead of every template rendered
- Flush cache on post save and use post ID for cache invalidation, instead of creating and comparing a [hash](https://en.wikipedia.org/wiki/Non-cryptographic_hash_function) of template content

Status: Working but experimental, needs testing
