### PR TITLE
Add WP Grid Builder facet integration to Post Loop

### DIFF
--- a/loop/types/post/index.php
+++ b/loop/types/post/index.php
@@ -279,7 +279,7 @@ class PostLoop extends BaseLoop {
       ],
 
       // WP Grid Builder integration
-      // @see https://docs.wpgridbuilder.com/resources/filter-custom-content
+      // @see https://docs.wpgridbuilder.com/resources/guide-filter-custom-queries/
       'wp_grid_builder' => [
         'description' => 'WP Grid Builder identifier for filtering content',
         'type'        => 'string',
@@ -1235,10 +1235,8 @@ class PostLoop extends BaseLoop {
 
     } // End query by custom field
 
-    /**
-     * WP Grid Builder integration
-     * @see https://docs.wpgridbuilder.com/resources/filter-custom-content
-     */
+    // WP Grid Builder integration
+    // @see https://docs.wpgridbuilder.com/resources/guide-filter-custom-queries/
     if (isset($this->args['wp_grid_builder'])) {
       $query_args['wp_grid_builder'] = $this->args['wp_grid_builder'];
     }

--- a/loop/types/post/index.php
+++ b/loop/types/post/index.php
@@ -278,8 +278,10 @@ class PostLoop extends BaseLoop {
         'type'        => 'string',
       ],
 
-      // WP Grid Builder integration
-      // @see https://docs.wpgridbuilder.com/resources/guide-filter-custom-queries/
+      /**
+       * WP Grid Builder facet integration
+       * @see https://docs.wpgridbuilder.com/resources/guide-filter-custom-queries/
+       */
       'wp_grid_builder' => [
         'description' => 'WP Grid Builder identifier for filtering content',
         'type'        => 'string',
@@ -1235,8 +1237,7 @@ class PostLoop extends BaseLoop {
 
     } // End query by custom field
 
-    // WP Grid Builder integration
-    // @see https://docs.wpgridbuilder.com/resources/guide-filter-custom-queries/
+    // WP Grid Builder facet integration
     if (isset($this->args['wp_grid_builder'])) {
       $query_args['wp_grid_builder'] = $this->args['wp_grid_builder'];
     }

--- a/loop/types/post/index.php
+++ b/loop/types/post/index.php
@@ -278,6 +278,12 @@ class PostLoop extends BaseLoop {
         'type'        => 'string',
       ],
 
+      // WP Grid Builder integration
+      // @see https://docs.wpgridbuilder.com/resources/filter-custom-content
+      'wp_grid_builder' => [
+        'description' => 'WP Grid Builder identifier for filtering content',
+        'type'        => 'string',
+      ],
 
       // Date field query
 
@@ -1229,6 +1235,14 @@ class PostLoop extends BaseLoop {
 
     } // End query by custom field
 
+    /**
+     * WP Grid Builder integration
+     * @see https://docs.wpgridbuilder.com/resources/filter-custom-content
+     */
+    if (isset($this->args['wp_grid_builder'])) {
+      $query_args['wp_grid_builder'] = $this->args['wp_grid_builder'];
+    }
+    
     /**
      * Custom query parameters
      */


### PR DESCRIPTION
This commit adds support for WP Grid Builder facet filtering to the Loops & Logic Post Loop.

Changes include:

- Add `wp_grid_builder` parameter to Post Loop configuration with documentation
- Add code to pass the parameter to `WP_Query`

This integration allows users to filter L&L loops with WP Grid Builder facets by adding the `wp_grid_builder` attribute to a `<Loop>` tag. Then the user just needs to match the arg value with the class applied to the outer wrapper element.

Example usage:
```
[wpgb_facet id="1" grid="wpgb-content-1"]

<ul class="wpgb-content-1">
  <Loop type=post wp_grid_builder=wpgb-content-1>
    <li><Field title /></li>
  </Loop>
</ul>
```

So in summary, after this update, the only things you need to do to connect a WPGB Facet to the `<Loop>` is you just have to add `wpgb-content-{whatever-suffix-you-want}` to:
- the facet shortcode in the `grid` attr
- the `class` on the loop item parent container
- and to a custom attr (`wp_grid_builder`) on the <Loop>

Documentation reference: https://docs.wpgridbuilder.com/resources/guide-filter-custom-queries/