### PR TITLE
Add support for WPGB Pagination Facet

### DIFF
--- a/integrations/wp-grid-builder/index.php
+++ b/integrations/wp-grid-builder/index.php
@@ -22,6 +22,17 @@ add_filter('wp_grid_builder/block/sources', function( $sources ) {
   return $sources;
 });
 
+add_filter('tangible_loop_tag_attributes', function($atts) {
+
+  // Handle WP Grid Builder pagination
+  if (isset($atts['wp_grid_builder']) && isset($atts['paged'])) {
+    $atts['posts_per_page'] = $atts['paged']; // Move `paged` value to `posts_per_page`
+    unset($atts['paged']); // Prevent L&L pagination from activating
+  }
+
+  return $atts;
+});
+
 require_once __DIR__ . '/settings.php';
 require_once __DIR__ . '/blocks.php';
 

--- a/language/tags/loop/index.php
+++ b/language/tags/loop/index.php
@@ -41,6 +41,9 @@ $html->loop_tag = function($atts, $nodes = []) use ($loop, $html) {
     }
 
   } else {
+    // Apply filter to allow extensions to modify loop attributes
+    $atts = apply_filters('tangible_loop_tag_attributes', $atts);
+    
     $current_loop = $html->create_loop_tag_context($atts);
   }
 

--- a/loop/types/post/index.php
+++ b/loop/types/post/index.php
@@ -335,6 +335,12 @@ class PostLoop extends BaseLoop {
         'type'        => 'number',
         'default'     => -1,
       ],
+      // Standard WP_Query posts per page parameter (currently only used for WPGB facet pagination)
+      'posts_per_page' => [
+        'target_name' => 'posts_per_page',
+        'description' => 'Posts per page',
+        'type'        => 'number',
+      ],
       'page'      => [
         'target_name' => 'paged',
         'description' => 'Page number',


### PR DESCRIPTION
This PR adds support for WP Grid Builder pagination facets when used with Loops & Logic loops. Previously, L&L's AJAX pagination system would conflict with WPGB's pagination facets when both were active at the same time. The issue and discussion can be found here: Resolves https://github.com/TangibleInc/template-system/issues/150

## Changes
**Added extension filter hook in Loop Tag Handler:**
 - Added `tangible_loop_tag_attributes` filter hook in the Loop tag handler to allow extension-specific modifications to loop attributes before the loop context is created
 
**Added posts_per_page parameter to PostLoop configuration:**
 - Added explicit support for the `posts_per_page parameter` in PostLoop's query arguments configuration. This ensures that when plugins need direct control over pagination parameters, they have a supported pathway
 
 **Implemented WP Grid Builder integration filter:**
 - Integration filter added to the WP Grid Builder extension file that hooks into the previously mentioned new `tangible_loop_tag_attributes` filter. This ensures that pagination works correctly when WPGB facets are used with L&L loops